### PR TITLE
NES fix when trying to inject a rom using a Base.

### DIFF
--- a/Tools/CONSOLES/NES/NES.bat
+++ b/Tools/CONSOLES/NES/NES.bat
@@ -214,7 +214,7 @@ IF errorlevel 1 goto :DownloadingStuff
 
 :DownloadingStuff
 cls
-IF %BASEDECIDE%==6 GOTO:EnterBaseCode
+IF %BASEDECIDE%==3 GOTO:EnterBaseCode
 echo Testing Internet connection...
 C:\windows\system32\PING.EXE google.com
 if %errorlevel% GTR 0 goto:InternetSucks


### PR DESCRIPTION
When 'Base supplied from Files' where selected, Injectiine tried to download files, but it threw an error 'Invalid title key'. Now works.